### PR TITLE
Catalog Yaml - Add new properties

### DIFF
--- a/CICD.Tools.CatalogUpload.Lib/CatalogMetaData.cs
+++ b/CICD.Tools.CatalogUpload.Lib/CatalogMetaData.cs
@@ -124,6 +124,21 @@
         public CatalogVersionMetaData Version { get; set; }
 
         /// <summary>
+        /// Gets or sets the vendor ID associated with the catalog entry.
+        /// </summary>
+        public string VendorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the market name associated with the catalog entry.
+        /// </summary>
+        public string MarketName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the element type associated with the catalog entry.
+        /// </summary>
+        public string ElementType { get; set; }
+
+        /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -142,7 +157,10 @@
                        Tags.SequenceEqual(other.Tags) && // List comparison
                        String.Equals(PathToReadme, other.PathToReadme, StringComparison.OrdinalIgnoreCase) &&
                        String.Equals(PathToImages, other.PathToImages, StringComparison.OrdinalIgnoreCase) &&
-                       Equals(Version, other.Version); // Version is an object, so we use Equals
+                       Equals(Version, other.Version) && // Version is an object, so we use Equals
+                       String.Equals(VendorId, other.VendorId, StringComparison.OrdinalIgnoreCase) &&
+                       String.Equals(MarketName, other.MarketName, StringComparison.OrdinalIgnoreCase) &&
+                       String.Equals(ElementType, other.ElementType, StringComparison.OrdinalIgnoreCase);
             }
             return false;
         }
@@ -171,7 +189,10 @@
 
             int hash3 = HashCode.Combine(
                 Tags != null ? String.Join(",", Tags).ToLower() : String.Empty,
-                Version
+                Version,
+                VendorId?.ToLower(),
+                MarketName?.ToLower(),
+                ElementType?.ToLower()
             );
 
             // Combine the intermediate hashes into a final hash.
@@ -269,6 +290,10 @@
 
                 if (!String.IsNullOrWhiteSpace(p.ShortDescription)) ShortDescription = p.ShortDescription;
                 if (!String.IsNullOrWhiteSpace(p.SourceCodeUrl)) SourceCodeUri = p.SourceCodeUrl;
+
+                if (!String.IsNullOrWhiteSpace(p.VendorId)) VendorId = p.VendorId;
+                if (!String.IsNullOrWhiteSpace(p.MarketName)) MarketName = p.MarketName;
+                if (!String.IsNullOrWhiteSpace(p.ElementType)) ElementType = p.ElementType;
 
                 p.Owners?.ForEach(o => { Owners.Add(new CatalogOwner { Name = o.Name, Email = o.Email, Url = o.Url }); });
                 p.Tags?.ForEach(Tags.Add);

--- a/CICD.Tools.CatalogUpload.Lib/CatalogService/CatalogYaml.cs
+++ b/CICD.Tools.CatalogUpload.Lib/CatalogService/CatalogYaml.cs
@@ -63,6 +63,21 @@
         /// </summary>
         /// <value>A string representing the type of the entry.</value>
         public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vendor ID associated with the catalog entry.
+        /// </summary>
+        public string VendorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the market name associated with the catalog entry.
+        /// </summary>
+        public string MarketName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the element type associated with the catalog entry.
+        /// </summary>
+        public string ElementType { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request extends the catalog metadata functionality by adding new properties related to vendor, market, and element type, and ensures these are properly handled throughout the codebase. The changes affect both the data model and its equality/hash logic, as well as the process of loading catalog data from YAML files.

**Enhancements to catalog metadata:**

* Added new properties `VendorId`, `MarketName`, and `ElementType` to the `CatalogMetaData` class, allowing catalog entries to store additional information about their vendor, market, and type.
* Updated the `CatalogYaml` class to include the same new properties, ensuring that YAML-based catalog definitions can specify vendor, market, and element type.

**Equality and hash code logic updates:**

* Modified the `Equals` and `GetHashCode` methods in `CatalogMetaData` to account for the new properties, ensuring correct comparison and hashing behavior when these fields are present. [[1]](diffhunk://#diff-c6c47a3e653439efb43af217920962b76fcb66d4ff22c16f00ce83e974db107bL145-R163) [[2]](diffhunk://#diff-c6c47a3e653439efb43af217920962b76fcb66d4ff22c16f00ce83e974db107bL174-R195)

**YAML loading and mapping:**

* Updated the `SearchAndApplyCatalogYamlAndReadMe` method to read the new fields from the parsed YAML object and assign them to the corresponding properties in `CatalogMetaData`.